### PR TITLE
fix(task): 禁言解除失败时不再中断循环

### DIFF
--- a/process/Task.php
+++ b/process/Task.php
@@ -118,9 +118,16 @@ class Task
             sublog('每日任务/解除禁言', "解除用户", [
                 'uid' => $item->tuid
             ]);
-            Bililive\Live::delSilentUser($room_id, $cookie, $item->black_id);
-            $item->delete();
-            sublog('每日任务/解除禁言', "解除成功", 'N/A');
+            try {
+                Bililive\Live::delSilentUser($room_id, $cookie, $item->black_id);
+                $item->delete();
+                sublog('每日任务/解除禁言', "解除成功", 'N/A');
+            } catch (\Exception $e) {
+                sublog('每日任务/解除禁言', "解除失败", [
+                    'uid' => $item->tuid,
+                    'error' => $e->getMessage()
+                ]);
+            }
         }
     }
 


### PR DESCRIPTION
Bililive\Live::delSilentUser 调用可能抛出异常导致整个循环崩溃。
添加 try-catch 捕获异常，失败时仅记录日志并继续处理下一个用户。