### PR TITLE
fix(config): 移除已删除文件的自动加载引用

### DIFF
--- a/config/autoload.php
+++ b/config/autoload.php
@@ -16,7 +16,5 @@
 return [
     'files' => [
         base_path() . '/app/functions.php',
-        base_path() . '/support/Request.php',
-        base_path() . '/support/Response.php',
     ]
 ];


### PR DESCRIPTION
support/Request.php 和 support/Response.php 已在上次重构中移除，清理 autoload.php 中残留的 files 引用。